### PR TITLE
Fixed README bug with absolute URL of image on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Visuals
-![Homepage](/client/public/images/example.png)
+![Homepage](https://raw.githubusercontent.com/Steveb175/Workout-Customizer/main/client/public/images/example.PNG)
 
 ## Description
 Workout Customizer is an application that allows users to find workouts and save them to their profile for easy access later on. It will assist users while they are working out by having all of their workouts easily accessible on one page with clear instructions on how to safely and effectively perform each exercise.
 
 ## Table of Contents
-- [Workout Customizer](#workout-customizer)
+- [Workout Customizer :muscle:](#workout-customizer-muscle)
   - [Visuals](#visuals)
   - [Description](#description)
   - [Table of Contents](#table-of-contents)

--- a/server/config/connection.js
+++ b/server/config/connection.js
@@ -1,4 +1,4 @@
-require("dotenv").config();
+require("dotenv").config({ path: "../.env" });
 const mongoose = require("mongoose");
 
 mongoose.connect(

--- a/server/utils/auth.js
+++ b/server/utils/auth.js
@@ -1,7 +1,7 @@
 const jwt = require("jsonwebtoken");
+require("dotenv").config({ path: "../.env" });
 
-// NEED TO ADD .ENV FILE WITH SECRET AT SOME POINT
-const secret = "Will-be-changed-to-env-variable";
+const secret = process.env.SECRET;
 const expiration = "2h";
 
 module.exports = {


### PR DESCRIPTION
I found a workaround with the bug by replacing the path with the absolute URL of the image itself being hosted on our github repository.